### PR TITLE
cmake build script -- multiplatform build

### DIFF
--- a/PCSX2_Core/CMakeLists.txt
+++ b/PCSX2_Core/CMakeLists.txt
@@ -1,0 +1,351 @@
+cmake_minimum_required(VERSION 2.8)
+
+# macOS deployment target needs to be set before 'project' to work
+if(APPLE AND NOT TARGET_IOS)
+	set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
+endif()
+
+project(PCSX2_Core)
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z")
+else()
+	set(CMAKE_CXX_STANDARD 14)
+	set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if(WIN32)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /MP")
+endif()
+
+if(ANDROID)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
+if(NOT CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE Release CACHE STRING
+		"Choose the type of build, options are: None Debug Release"
+		FORCE)
+endif()
+
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG")
+
+add_definitions(-D_CONSOLE)
+
+include_directories(./src)
+
+set(COMMON_HEADER_FILES
+	src/Common/Global/CompileOptions.h
+	src/Common/Global/Constants.h
+	src/Common/Global/Globals.h
+	src/Common/Global/Log.h
+	src/Common/Global/Macros.h
+	src/Common/Global/PrimativeTypes.h
+	src/Common/Tables/EECoreExceptionsTable.h
+	src/Common/Tables/EECoreInstructionTable.h
+	src/Common/Tables/EECoreSyscallTable.h
+	src/Common/Tables/EEDmacChannelTable.h
+	src/Common/Tables/IOPCoreExceptionsTable.h
+	src/Common/Tables/IOPCoreInstructionTable.h
+	src/Common/Tables/IOPCoreSyscallTable.h
+	src/Common/Tables/IOPDmacChannelTable.h
+	src/Common/Tables/SPU2CoreTable.h
+	src/Common/Tables/VIFcodeInstructionTable.h
+	src/Common/Types/ByteMMU/ByteMMU_t.h
+	src/Common/Types/ByteMMU/MapperBaseObjectByteMMU_t.h
+	src/Common/Types/ByteMMU/MapperByteMemoryByteMMU_t.h
+	src/Common/Types/ByteMMU/MapperFIFOQueueByteMMU_t.h
+	src/Common/Types/ByteMMU/MapperRegister128ByteMMU_t.h
+	src/Common/Types/ByteMMU/MapperRegister16ByteMMU_t.h
+	src/Common/Types/ByteMMU/MapperRegister32ByteMMU_t.h
+	src/Common/Types/ByteMMU/MapperRegister64ByteMMU_t.h
+	src/Common/Types/ByteMMU/MapperRegister8ByteMMU_t.h
+	src/Common/Types/ClockSource_t.h
+	src/Common/Types/DebugBaseObject_t.h
+	src/Common/Types/EnumMap_t.h
+	src/Common/Types/FIFOQueue/FIFOQueue_t.h
+	src/Common/Types/MIPS/MIPSCoprocessor0_t.h
+	src/Common/Types/MIPS/MIPSCoprocessor_t.h
+	src/Common/Types/MIPS/MIPSInstructionInfo_t.h
+	src/Common/Types/MIPS/MIPSInstruction_t.h
+	src/Common/Types/MIPS/MIPSOperatingContext_t.h
+	src/Common/Types/Memory/ByteMemory_t.h
+	src/Common/Types/Memory/ConstantByteMemory_t.h
+	src/Common/Types/Memory/HwordMemory_t.h
+	src/Common/Types/Memory/ROByteMemory_t.h
+	src/Common/Types/Register/BitfieldRegister16_t.h
+	src/Common/Types/Register/BitfieldRegister32_t.h
+	src/Common/Types/Register/ConstantRegister128_t.h
+	src/Common/Types/Register/ConstantRegister16_t.h
+	src/Common/Types/Register/ConstantRegister32_t.h
+	src/Common/Types/Register/ConstantRegister8_t.h
+	src/Common/Types/Register/LinkRegister128_t.h
+	src/Common/Types/Register/LinkRegister32_t.h
+	src/Common/Types/Register/MapperRegister16Register32_t.h
+	src/Common/Types/Register/PCRegister16_t.h
+	src/Common/Types/Register/PCRegister32_t.h
+	src/Common/Types/Register/PairRegister16_t.h
+	src/Common/Types/Register/Register128_t.h
+	src/Common/Types/Register/Register16_t.h
+	src/Common/Types/Register/Register32_t.h
+	src/Common/Types/Register/Register64_t.h
+	src/Common/Types/Register/Register8_t.h
+	src/Common/Types/System_t.h
+	src/Common/Util/FPUUtil/FPUFlags_t.h
+	src/Common/Util/FPUUtil/FPUUtil.h
+	src/Common/Util/MathUtil/MathUtil.h
+	src/Resources/CDVD/CDVD_t.h
+	src/Resources/CDVD/Types/CDVDFIFOQueues_t.h
+	src/Resources/CDVD/Types/CDVDNvrams_t.h
+	src/Resources/CDVD/Types/CDVDRegisters_t.h
+	src/Resources/Clock/Clock_t.h
+	src/Resources/Common/Common_t.h
+	src/Resources/Common/Types/SBUSFIFOQueues_t.h
+	src/Resources/Common/Types/SBUSRegisters_t.h
+	src/Resources/EE/DMAC/EEDmac_t.h
+	src/Resources/EE/DMAC/Types/EEDMAtag_t.h
+	src/Resources/EE/DMAC/Types/EEDmacChannelRegisters_t.h
+	src/Resources/EE/DMAC/Types/EEDmacChannels_t.h
+	src/Resources/EE/DMAC/Types/EEDmacRegisters_t.h
+	src/Resources/EE/EECore/EECore_t.h
+	src/Resources/EE/EECore/Types/EECoreCOP0Registers_t.h
+	src/Resources/EE/EECore/Types/EECoreCOP0_t.h
+	src/Resources/EE/EECore/Types/EECoreException_t.h
+	src/Resources/EE/EECore/Types/EECoreFPURegisters_t.h
+	src/Resources/EE/EECore/Types/EECoreFPU_t.h
+	src/Resources/EE/EECore/Types/EECoreInstruction_t.h
+	src/Resources/EE/EECore/Types/EECoreR5900_t.h
+	src/Resources/EE/EECore/Types/EECoreTLBEntry_t.h
+	src/Resources/EE/EECore/Types/EECoreTLB_t.h
+	src/Resources/EE/EE_t.h
+	src/Resources/EE/GIF/GIF_t.h
+	src/Resources/EE/INTC/EEIntc_t.h
+	src/Resources/EE/INTC/Types/EEIntcRegisters_t.h
+	src/Resources/EE/IPU/IPU_t.h
+	src/Resources/EE/Timers/EETimers_t.h
+	src/Resources/EE/Timers/Types/EETimersTimerRegisters_t.h
+	src/Resources/EE/Timers/Types/EETimersTimers_t.h
+	src/Resources/EE/Types/EERegisters_t.h
+	src/Resources/EE/VPU/Types/VPURegisters_t.h
+	src/Resources/EE/VPU/VIF/Types/VIFCoreRegisters_t.h
+	src/Resources/EE/VPU/VIF/Types/VIFCores_t.h
+	src/Resources/EE/VPU/VIF/Types/VIFcodeInstruction_t.h
+	src/Resources/EE/VPU/VIF/VIF_t.h
+	src/Resources/EE/VPU/VPU_t.h
+	src/Resources/EE/VPU/VU/Types/VUCoreRegisters_t.h
+	src/Resources/EE/VPU/VU/Types/VUCores_t.h
+	src/Resources/EE/VPU/VU/Types/VUInstruction_t.h
+	src/Resources/EE/VPU/VU/Types/VURegisters_t.h
+	src/Resources/EE/VPU/VU/VU_t.h
+	src/Resources/GS/CRTC/CRTC_t.h
+	src/Resources/GS/GS_t.h
+	src/Resources/IOP/DMAC/IOPDmac_t.h
+	src/Resources/IOP/DMAC/Types/IOPDMAtag_t.h
+	src/Resources/IOP/DMAC/Types/IOPDmacChannelRegisters_t.h
+	src/Resources/IOP/DMAC/Types/IOPDmacChannels_t.h
+	src/Resources/IOP/DMAC/Types/IOPDmacRegisters_t.h
+	src/Resources/IOP/INTC/IOPIntc_t.h
+	src/Resources/IOP/INTC/Types/IOPIntcRegisters_t.h
+	src/Resources/IOP/IOPCore/IOPCore_t.h
+	src/Resources/IOP/IOPCore/Types/IOPCoreCOP0Registers_t.h
+	src/Resources/IOP/IOPCore/Types/IOPCoreCOP0_t.h
+	src/Resources/IOP/IOPCore/Types/IOPCoreException_t.h
+	src/Resources/IOP/IOPCore/Types/IOPCoreInstruction_t.h
+	src/Resources/IOP/IOPCore/Types/IOPCoreR3000_t.h
+	src/Resources/IOP/IOP_t.h
+	src/Resources/IOP/Timers/IOPTimers_t.h
+	src/Resources/IOP/Timers/Types/IOPTimersTimerRegisters_t.h
+	src/Resources/IOP/Timers/Types/IOPTimersTimers_t.h
+	src/Resources/Resources_t.h
+	src/Resources/SIO2/SIO2_t.h
+	src/Resources/SIO2/Types/SIO2Packet_t.h
+	src/Resources/SPU2/SPU2_t.h
+	src/Resources/SPU2/Types/SPU2CoreRegisters_t.h
+	src/Resources/SPU2/Types/SPU2CoreVoiceRegisters_t.h
+	src/Resources/SPU2/Types/SPU2CoreVoices_t.h
+	src/Resources/SPU2/Types/SPU2Cores_t.h
+	src/Resources/SPU2/Types/SPU2Registers_t.h
+	src/VM/Systems/CDVD/CDVD_s.h
+	src/VM/Systems/EE/DMAC/EEDmac_s.h
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_s.h
+	src/VM/Systems/EE/INTC/EEIntc_s.h
+	src/VM/Systems/EE/Timers/EETimers_s.h
+	src/VM/Systems/EE/VPU/VIF/VIF_s.h
+	src/VM/Systems/EE/VPU/VUInterpreter/VUInterpreter_s.h
+	src/VM/Systems/GS/CRTC/CRTC_s.h
+	src/VM/Systems/GS/GSCore/GSCore_s.h
+	src/VM/Systems/IOP/DMAC/IOPDmac_s.h
+	src/VM/Systems/IOP/INTC/IOPIntc_s.h
+	src/VM/Systems/IOP/IOPCoreInterpreter/IOPCoreInterpreter_s.h
+	src/VM/Systems/IOP/Timers/IOPTimers_s.h
+	src/VM/Systems/SPU2/SPU2_s.h
+	src/VM/Types/VMOptions.h
+	src/VM/Types/VMSystem_s.h
+	src/VM/VM.h
+)
+
+set(COMMON_SRC_FILES
+src/Common/Global/Log.cpp
+	src/Common/Tables/EECoreExceptionsTable.cpp
+	src/Common/Tables/EECoreInstructionTable.cpp
+	src/Common/Tables/EECoreSyscallTable.cpp
+	src/Common/Tables/EEDmacChannelTable.cpp
+	src/Common/Tables/IOPCoreExceptionsTable.cpp
+	src/Common/Tables/IOPCoreInstructionTable.cpp
+	src/Common/Tables/IOPCoreSyscallTable.cpp
+	src/Common/Tables/IOPDmacChannelTable.cpp
+	src/Common/Tables/SPU2CoreTable.cpp
+	src/Common/Tables/VIFcodeInstructionTable.cpp
+	src/Common/Types/ByteMMU/ByteMMU_t.cpp
+	src/Common/Types/ByteMMU/MapperBaseObjectByteMMU_t.cpp
+	src/Common/Types/ByteMMU/MapperByteMemoryByteMMU_t.cpp
+	src/Common/Types/ByteMMU/MapperFIFOQueueByteMMU_t.cpp
+	src/Common/Types/ByteMMU/MapperRegister128ByteMMU_t.cpp
+	src/Common/Types/ByteMMU/MapperRegister16ByteMMU_t.cpp
+	src/Common/Types/ByteMMU/MapperRegister32ByteMMU_t.cpp
+	src/Common/Types/ByteMMU/MapperRegister64ByteMMU_t.cpp
+	src/Common/Types/ByteMMU/MapperRegister8ByteMMU_t.cpp
+	src/Common/Types/FIFOQueue/FIFOQueue_t.cpp
+	src/Common/Types/MIPS/MIPSInstruction_t.cpp
+	src/Common/Types/Memory/ByteMemory_t.cpp
+	src/Common/Types/Memory/ConstantByteMemory_t.cpp
+	src/Common/Types/Memory/HwordMemory_t.cpp
+	src/Common/Types/Memory/ROByteMemory_t.cpp
+	src/Common/Types/Register/BitfieldRegister16_t.cpp
+	src/Common/Types/Register/BitfieldRegister32_t.cpp
+	src/Common/Types/Register/ConstantRegister128_t.cpp
+	src/Common/Types/Register/ConstantRegister16_t.cpp
+	src/Common/Types/Register/ConstantRegister32_t.cpp
+	src/Common/Types/Register/ConstantRegister8_t.cpp
+	src/Common/Types/Register/LinkRegister128_t.cpp
+	src/Common/Types/Register/LinkRegister32_t.cpp
+	src/Common/Types/Register/MapperRegister16Register32_t.cpp
+	src/Common/Types/Register/PCRegister16_t.cpp
+	src/Common/Types/Register/PCRegister32_t.cpp
+	src/Common/Types/Register/PairRegister16_t.cpp
+	src/Common/Types/Register/Register128_t.cpp
+	src/Common/Types/Register/Register16_t.cpp
+	src/Common/Types/Register/Register32_t.cpp
+	src/Common/Types/Register/Register64_t.cpp
+	src/Common/Types/Register/Register8_t.cpp
+	src/Common/Util/FPUUtil/FPUUtil.cpp
+	src/Common/Util/MathUtil/MathUtil.cpp
+	src/Resources/CDVD/CDVD_t.cpp
+	src/Resources/CDVD/Types/CDVDFIFOQueues_t.cpp
+	src/Resources/CDVD/Types/CDVDNvrams_t.cpp
+	src/Resources/CDVD/Types/CDVDRegisters_t.cpp
+	src/Resources/Clock/Clock_t.cpp
+	src/Resources/Common/Common_t.cpp
+	src/Resources/Common/Types/SBUSFIFOQueues_t.cpp
+	src/Resources/Common/Types/SBUSRegisters_t.cpp
+	src/Resources/EE/DMAC/EEDmac_t.cpp
+	src/Resources/EE/DMAC/Types/EEDmacChannelRegisters_t.cpp
+	src/Resources/EE/DMAC/Types/EEDmacChannels_t.cpp
+	src/Resources/EE/DMAC/Types/EEDmacRegisters_t.cpp
+	src/Resources/EE/EECore/EECore_t.cpp
+	src/Resources/EE/EECore/Types/EECoreCOP0Registers_t.cpp
+	src/Resources/EE/EECore/Types/EECoreCOP0_t.cpp
+	src/Resources/EE/EECore/Types/EECoreFPURegisters_t.cpp
+	src/Resources/EE/EECore/Types/EECoreFPU_t.cpp
+	src/Resources/EE/EECore/Types/EECoreInstruction_t.cpp
+	src/Resources/EE/EECore/Types/EECoreR5900_t.cpp
+	src/Resources/EE/EECore/Types/EECoreTLB_t.cpp
+	src/Resources/EE/EE_t.cpp
+	src/Resources/EE/GIF/GIF_t.cpp
+	src/Resources/EE/INTC/EEIntc_t.cpp
+	src/Resources/EE/INTC/Types/EEIntcRegisters_t.cpp
+	src/Resources/EE/IPU/IPU_t.cpp
+	src/Resources/EE/Timers/EETimers_t.cpp
+	src/Resources/EE/Timers/Types/EETimersTimerRegisters_t.cpp
+	src/Resources/EE/Timers/Types/EETimersTimers_t.cpp
+	src/Resources/EE/Types/EERegisters_t.cpp
+	src/Resources/EE/VPU/Types/VPURegisters_t.cpp
+	src/Resources/EE/VPU/VIF/Types/VIFCoreRegisters_t.cpp
+	src/Resources/EE/VPU/VIF/Types/VIFCores_t.cpp
+	src/Resources/EE/VPU/VIF/Types/VIFcodeInstruction_t.cpp
+	src/Resources/EE/VPU/VIF/VIF_t.cpp
+	src/Resources/EE/VPU/VPU_t.cpp
+	src/Resources/EE/VPU/VU/Types/VUCoreRegisters_t.cpp
+	src/Resources/EE/VPU/VU/Types/VUCores_t.cpp
+	src/Resources/EE/VPU/VU/Types/VUInstruction_t.cpp
+	src/Resources/EE/VPU/VU/Types/VURegisters_t.cpp
+	src/Resources/EE/VPU/VU/VU_t.cpp
+	src/Resources/GS/CRTC/CRTC_t.cpp
+	src/Resources/GS/GS_t.cpp
+	src/Resources/IOP/DMAC/IOPDmac_t.cpp
+	src/Resources/IOP/DMAC/Types/IOPDmacChannelRegisters_t.cpp
+	src/Resources/IOP/DMAC/Types/IOPDmacChannels_t.cpp
+	src/Resources/IOP/DMAC/Types/IOPDmacRegisters_t.cpp
+	src/Resources/IOP/INTC/IOPIntc_t.cpp
+	src/Resources/IOP/INTC/Types/IOPIntcRegisters_t.cpp
+	src/Resources/IOP/IOPCore/IOPCore_t.cpp
+	src/Resources/IOP/IOPCore/Types/IOPCoreCOP0Registers_t.cpp
+	src/Resources/IOP/IOPCore/Types/IOPCoreCOP0_t.cpp
+	src/Resources/IOP/IOPCore/Types/IOPCoreInstruction_t.cpp
+	src/Resources/IOP/IOPCore/Types/IOPCoreR3000_t.cpp
+	src/Resources/IOP/IOP_t.cpp
+	src/Resources/IOP/Timers/IOPTimers_t.cpp
+	src/Resources/IOP/Timers/Types/IOPTimersTimerRegisters_t.cpp
+	src/Resources/IOP/Timers/Types/IOPTimersTimers_t.cpp
+	src/Resources/Resources_t.cpp
+	src/Resources/SIO2/SIO2_t.cpp
+	src/Resources/SPU2/SPU2_t.cpp
+	src/Resources/SPU2/Types/SPU2CoreRegisters_t.cpp
+	src/Resources/SPU2/Types/SPU2CoreVoiceRegisters_t.cpp
+	src/Resources/SPU2/Types/SPU2CoreVoices_t.cpp
+	src/Resources/SPU2/Types/SPU2Cores_t.cpp
+	src/Resources/SPU2/Types/SPU2Registers_t.cpp
+	src/VM/Systems/CDVD/CDVD_SCMD.cpp
+	src/VM/Systems/CDVD/CDVD_s.cpp
+	src/VM/Systems/EE/DMAC/EEDmac_CHAIN.cpp
+	src/VM/Systems/EE/DMAC/EEDmac_s.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_ALU_OTHERS.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_BREAK_TRAP.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_CALL.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_COMPARE.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_COND_BRANCH_JUMP.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_COP2.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_DFC.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_FLOAT.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_INTEGER_ADD_SUB.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_INTEGER_MULT_ADD.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_INTEGER_MULT_DIV.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_LOAD_MEM.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_LOGICAL.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_MIN_MAX.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_OTHERS.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_REG_TRANSFER.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_REORDERING.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_SHIFT.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_SPECIAL_TRANSFER.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_STORE_MEM.cpp
+	src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_s.cpp
+	src/VM/Systems/EE/INTC/EEIntc_s.cpp
+	src/VM/Systems/EE/Timers/EETimers_s.cpp
+	src/VM/Systems/EE/VPU/VIF/VIF_s.cpp
+	src/VM/Systems/EE/VPU/VUInterpreter/VUInterpreter_CONVERT.cpp
+	src/VM/Systems/EE/VPU/VUInterpreter/VUInterpreter_EFU.cpp
+	src/VM/Systems/EE/VPU/VUInterpreter/VUInterpreter_FLAG.cpp
+	src/VM/Systems/EE/VPU/VUInterpreter/VUInterpreter_FLOAT.cpp
+	src/VM/Systems/EE/VPU/VUInterpreter/VUInterpreter_INTEGER.cpp
+	src/VM/Systems/EE/VPU/VUInterpreter/VUInterpreter_OTHER.cpp
+	src/VM/Systems/EE/VPU/VUInterpreter/VUInterpreter_TRANSFER.cpp
+	src/VM/Systems/EE/VPU/VUInterpreter/VUInterpreter_s.cpp
+	src/VM/Systems/GS/CRTC/CRTC_s.cpp
+	src/VM/Systems/GS/GSCore/GSCore_s.cpp
+	src/VM/Systems/IOP/DMAC/IOPDmac_s.cpp
+	src/VM/Systems/IOP/INTC/IOPIntc_s.cpp
+	src/VM/Systems/IOP/IOPCoreInterpreter/IOPCoreInterpreter_ALU.cpp
+	src/VM/Systems/IOP/IOPCoreInterpreter/IOPCoreInterpreter_BRANCH_JUMP.cpp
+	src/VM/Systems/IOP/IOPCoreInterpreter/IOPCoreInterpreter_LOAD_STORE_MEM.cpp
+	src/VM/Systems/IOP/IOPCoreInterpreter/IOPCoreInterpreter_OTHERS.cpp
+	src/VM/Systems/IOP/IOPCoreInterpreter/IOPCoreInterpreter_SPECIAL_TRANSFER.cpp
+	src/VM/Systems/IOP/IOPCoreInterpreter/IOPCoreInterpreter_s.cpp
+	src/VM/Systems/IOP/Timers/IOPTimers_s.cpp
+	src/VM/Systems/SPU2/SPU2_s.cpp
+	src/VM/Types/VMSystem_s.cpp
+	src/VM/VM.cpp
+)
+
+add_library(PCSX2_Core STATIC ${COMMON_SRC_FILES} ${COMMON_HEADER_FILES})

--- a/PCSX2_Core/src/Common/Types/Register/BitfieldRegister16_t.cpp
+++ b/PCSX2_Core/src/Common/Types/Register/BitfieldRegister16_t.cpp
@@ -88,7 +88,7 @@ void BitfieldRegister16_t::logDebugAllFields() const
 #if DEBUG_LOG_VALUE_AS_HEX
 		log(Debug, "\t%s = 0x%X.", field.mMnemonic.c_str(), MathUtil::extractMaskedValue16(UH, field.mStartPosition, field.mLength));
 #else
-		log(Debug, "\t%s = %d.", field.mMnemonic, MathUtil::extractMaskedValue16(UH, field.mStartPosition, field.mLength));
+		log(Debug, "\t%s = %d.", field.mMnemonic.c_str(), MathUtil::extractMaskedValue16(UH, field.mStartPosition, field.mLength));
 #endif
 	}
 }

--- a/PCSX2_Core/src/Common/Types/Register/BitfieldRegister32_t.cpp
+++ b/PCSX2_Core/src/Common/Types/Register/BitfieldRegister32_t.cpp
@@ -110,7 +110,7 @@ void BitfieldRegister32_t::logDebugAllFields() const
 #if DEBUG_LOG_VALUE_AS_HEX
 		log(Debug, "\t%s = 0x%X.", field.mMnemonic.c_str(), MathUtil::extractMaskedValue32(UW, field.mStartPosition, field.mLength));
 #else
-		log(Debug, "\t%s = %d.", field.mMnemonic, MathUtil::extractMaskedValue32(UW, field.mStartPosition, field.mLength));
+		log(Debug, "\t%s = %d.", field.mMnemonic.c_str(), MathUtil::extractMaskedValue32(UW, field.mStartPosition, field.mLength));
 #endif
 	}
 }

--- a/PCSX2_Core/src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_ALU_OTHERS.cpp
+++ b/PCSX2_Core/src/VM/Systems/EE/EECoreInterpreter/EECoreInterpreter_ALU_OTHERS.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <cstdlib>
 
 #include "Common/Global/Globals.h"
 #include "Common/Types/Register/Register128_t.h"

--- a/PCSX2_Frontend/CMakeLists.txt
+++ b/PCSX2_Frontend/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 2.8)
+
+# macOS deployment target needs to be set before 'project' to work
+if(APPLE AND NOT TARGET_IOS)
+	set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
+endif()
+
+project(PCSX2_Core)
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z")
+else()
+	set(CMAKE_CXX_STANDARD 14)
+	set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if(WIN32)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /MP")
+endif()
+
+if(ANDROID)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
+if(NOT CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE Release CACHE STRING
+		"Choose the type of build, options are: None Debug Release"
+		FORCE)
+endif()
+
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG")
+
+if (NOT TARGET PCSX2_Core)
+	add_subdirectory(
+		${CMAKE_CURRENT_SOURCE_DIR}/../PCSX2_Core
+		${CMAKE_CURRENT_BINARY_DIR}/PCSX2_Core
+	)
+endif()
+list(APPEND PROJECT_LIBS PCSX2_Core)
+
+find_package(Threads REQUIRED)
+if(CMAKE_THREAD_LIBS_INIT)
+	list(APPEND PROJECT_LIBS "${CMAKE_THREAD_LIBS_INIT}")
+endif()
+
+add_definitions(-D_CONSOLE)
+
+include_directories(../PCSX2_Core/src ./src)
+
+set(COMMON_HEADER_FILES
+)
+
+set(COMMON_SRC_FILES
+	src/PCSX2_Frontend.cpp
+)
+
+add_executable(PCSX2_Frontend ${COMMON_HEADER_FILES} ${COMMON_SRC_FILES})
+target_link_libraries(PCSX2_Frontend ${PROJECT_LIBS})
+
+if(THREADS_HAVE_PTHREAD_ARG)
+		target_compile_options(PUBLIC PCSX2_Frontend "-pthread")
+endif()


### PR DESCRIPTION
also, it seems the compilation can't be fixed on OSX with `-std=c++1z`, perhaps because their compiler lacks behind standard clang build? it so, you can either go back and fix things, or wait for newer builds (I'm on Xcode 8.2.1, latest is 8.3.2 so ill update it later and see)

Tested on OSX/Ubuntu 17.04

P.S. Visual Studio is refusing to install, so i can't test the windows build, if you can please test it.

```
cd PCSX2_rewrite
mkdir build
cd build

cmake ../PCSX2_Frontend/ -G"Visual Studio 14 2015 Win64"
# or if you're on the latest
cmake ../PCSX2_Frontend/ -G"Visual Studio 15 2016 Win64"

cmake --build . --config Release
```